### PR TITLE
fixed issue with nonexistent word

### DIFF
--- a/bin/dicio
+++ b/bin/dicio
@@ -6,35 +6,43 @@ var diacritics = require('diacritic');
 var http = require('http');
 var iconv = require('iconv-lite');
 
-var error = function() {
-    return failure('Serviço indisponível.');
-}
-
 var failure = function(error) {
     process.stderr.write(error + '\n');
     process.exit(1);
 };
 
+var serviceUnavailable = function() {
+    return failure('Serviço indisponível.');
+}
+
 var success = function(response) {
+    if (response.statusCode === 302) {
+        return wordNotFound();
+    }
+
     if (response.statusCode !== 200) {
-        return error();
+        return serviceUnavailable();
     }
 
     response.pipe(iconv.decodeStream('ISO-8859-1')).collect(function(error, body) {
         var re = /class='descricao'>/;
 
         if (!re.test(body)) {
-            return failure('Palavra não encontrada.');
+            return wordNotFound();
         }
 
         var text = body.split(re)[1].split('</span>')[0];
 
         if (!text.length) {
-            return failure('Palavra não encontrada.');
+            return wordNotFound();
         }
 
         process.stdout.write(text.replace(/<br>/g, ' ') + '\n');
     });
+};
+
+var wordNotFound = function() {
+    return failure('Palavra não encontrada.');
 };
 
 var argv = diacritics.clean(process.argv[2]).toLowerCase();
@@ -45,4 +53,4 @@ if (!argv.length) {
 
 var url = 'http://dicionariodoaurelio.com/' + argv;
 
-http.get(url, success).on('error', error);
+http.get(url, success).on('error', serviceUnavailable);


### PR DESCRIPTION
Com a remoção do `request` o código deixou de seguir redirecionamentos, que ocorrem quando uma palavra não é encontrada. Por isso estava retornando `serviço indisponível` ao invés de `palavra não encontrada`.
